### PR TITLE
Remove Exporter from Graph and Graph::__toString()

### DIFF
--- a/lib/Fhaculty/Graph/Graph.php
+++ b/lib/Fhaculty/Graph/Graph.php
@@ -2,8 +2,6 @@
 
 namespace Fhaculty\Graph;
 
-use Fhaculty\Graph\Exporter\ExporterInterface;
-use Fhaculty\Graph\Exporter\TrivialGraphFormat;
 use Fhaculty\Graph\Exception\BadMethodCallException;
 use Fhaculty\Graph\Exception\UnexpectedValueException;
 use Fhaculty\Graph\Exception\InvalidArgumentException;
@@ -26,12 +24,6 @@ use Fhaculty\Graph\Attribute\AttributeBagReference;
 
 class Graph implements DualAggregate, AttributeAware
 {
-    /**
-     * @var ExporterInterface|null
-     * @see self::setExporter()
-     */
-    protected $exporter = null;
-
     protected $verticesStorage = array();
     protected $vertices;
 
@@ -458,47 +450,6 @@ class Graph implements DualAggregate, AttributeAware
         // @codeCoverageIgnoreStart
         throw new BadMethodCallException();
         // @codeCoverageIgnoreEnd
-    }
-
-    /**
-     * set a new exporter to use when calling __toString()
-     *
-     * @param ExporterInterface $exporter
-     * @return \Fhaculty\Graph\Graph $this (chainable)
-     */
-    public function setExporter(ExporterInterface $exporter)
-    {
-        $this->exporter = $exporter;
-        return $this;
-    }
-
-    /**
-     * get current exporter to use to export graph to its output format
-     *
-     * If no other exporter has been set previously, this will lazy-load
-     * the (current default) TrivialGraphFormat exporter.
-     *
-     * @return ExporterInterface
-     */
-    public function getExporter()
-    {
-        if ($this->exporter === null) {
-            $this->exporter = new TrivialGraphFormat();
-        }
-        return $this->exporter;
-    }
-
-    /**
-     * export graph to its output format
-     *
-     * this is a magic method that will be called automatically when you
-     * call `echo $graph;`.
-     * @uses self::getExporter()
-     * @uses ExporterInterface::getOutput()
-     */
-    public function __toString()
-    {
-        return $this->getExporter()->getOutput($this);
     }
 
     public function getAttribute($name, $default = null)

--- a/tests/Fhaculty/Graph/GraphTest.php
+++ b/tests/Fhaculty/Graph/GraphTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Fhaculty\Graph\Exception\RuntimeException;
-use Fhaculty\Graph\Exporter\Image;
 use Fhaculty\Graph\Vertex;
 use Fhaculty\Graph\Exception\OverflowException;
 use Fhaculty\Graph\Exception\InvalidArgumentException;
@@ -132,30 +131,6 @@ class GraphTest extends TestCase
         $v1again = $graph->createVertex(1, true);
 
         $this->assertSame($v1, $v1again);
-    }
-
-    public function testExporter()
-    {
-        $graph = new Graph();
-        $graph->createVertex(1)->createEdge($graph->createVertex(2));
-
-        $this->assertNotEquals('', (string)$graph);
-
-        $this->assertInstanceOf('\\Fhaculty\\Graph\\Exporter\\ExporterInterface', $graph->getExporter());
-    }
-
-    public function testExporterGetSet()
-    {
-        $graph = new Graph();
-
-        $exporter = $graph->getExporter();
-
-        $this->assertInstanceOf('Fhaculty\Graph\Exporter\ExporterInterface', $exporter);
-
-        // multiple calls should return the same exporter
-        $this->assertSame($exporter, $graph->getExporter());
-
-        $graph->setExporter($exporter);
     }
 
     public function testHasVertex()


### PR DESCRIPTION
This PR removes all references of the `Exporter` from the main `Graph` class, and hence its `__toString()` method, some reasons being:

* This library will be split into smaller components (#120)
* The `Exporter` namespace will be split off into a separate package (#121).
* Also, see #23 for details why `__toString()` is to be avoided.