### PR TITLE
Cannot delete a vertex with a loop

### DIFF
--- a/src/Vertex.php
+++ b/src/Vertex.php
@@ -354,7 +354,7 @@ class Vertex implements EdgesAggregate, AttributeAware
      */
     public function destroy()
     {
-        foreach ($this->edges as $edge) {
+        foreach ($this->getEdges()->getEdgesDistinct() as $edge) {
             $edge->destroy();
         }
         $this->graph->removeVertex($this);

--- a/tests/Edge/EdgeBaseTest.php
+++ b/tests/Edge/EdgeBaseTest.php
@@ -99,6 +99,18 @@ abstract class EdgeBaseTest extends AbstractAttributeAwareTest
         $this->assertSame($this->v1, $edge->getVertexToFrom($this->v1));
     }
 
+    public function testRemoveWithLoop()
+    {
+        $edge = $this->createEdgeLoop();
+
+        $this->assertEquals(array($this->edge, $edge), $this->graph->getEdges()->getVector());
+
+        $edge->destroy();
+
+        $this->assertEquals(array($this->edge), $this->graph->getEdges()->getVector());
+        $this->assertEquals(array($this->v1, $this->v2), $this->graph->getVertices()->getVector());
+    }
+
     protected function createAttributeAware()
     {
         return $this->createEdge();

--- a/tests/VertexTest.php
+++ b/tests/VertexTest.php
@@ -136,6 +136,32 @@ class VertexTest extends AbstractAttributeAwareTest
         $this->vertex->removeEdge($edge);
     }
 
+    public function testRemoveWithEdgeLoopUndirected()
+    {
+        // 1 -- 1
+        $edge = $this->vertex->createEdge($this->vertex);
+
+        $this->assertEquals(array(1 => $this->vertex), $this->graph->getVertices()->getMap());
+
+        $this->vertex->destroy();
+
+        $this->assertEquals(array(), $this->graph->getVertices()->getVector());
+        $this->assertEquals(array(), $this->graph->getEdges()->getVector());
+    }
+
+    public function testRemoveWithEdgeLoopDirected()
+    {
+        // 1 --> 1
+        $edge = $this->vertex->createEdgeTo($this->vertex);
+
+        $this->assertEquals(array(1 => $this->vertex), $this->graph->getVertices()->getMap());
+
+        $this->vertex->destroy();
+
+        $this->assertEquals(array(), $this->graph->getVertices()->getVector());
+        $this->assertEquals(array(), $this->graph->getEdges()->getVector());
+    }
+
     protected function createAttributeAware()
     {
         return new Vertex(new Graph(), 1);


### PR DESCRIPTION
I don't know if this is the most appropriate way to post this, but here goes.

It is currently not possible to delete a vertex as when the code attempts to delete the second part of the loop edge, `throw new OutOfBoundsException('Given edge does NOT exist');` is thrown.

I'm unsure if it makes sense for the same edge to be part of the edge list twice (one for both end) as it will attempt to delete said edge twice.

Please advise on your suggested fix.

Thanks!

Note: This PR includes another of my PR which you can hopefully ignore.